### PR TITLE
Cleanup profile_list default handling

### DIFF
--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2963,8 +2963,11 @@ class KubeSpawner(Spawner):
         if not self.profile_list:
             return ''
         if callable(self.profile_list):
+            # Return the function dynamically, so JupyterHub will call this when the
+            # form needs rendering
             return self._render_options_form_dynamically
         else:
+            # Return the rendered string, as it does not change
             return self._render_options_form(self.profile_list)
 
     @default('options_from_form')

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3070,7 +3070,6 @@ class KubeSpawner(Spawner):
                     return profile
 
             # A slug is specified, but not found
-            # name specified, but not found
             raise ValueError(
                 "No such profile: %s. Options include: %s"
                 % (slug, ', '.join(p['slug'] for p in profile_list))

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3187,7 +3187,8 @@ class KubeSpawner(Spawner):
             if 'slug' not in profile:
                 profile['slug'] = slugify(profile['display_name'])
 
-            # If profile_options are present with choices, but no
+            # If profile_options are present with choices, but no default choice
+            # is specified, we make the first choice the default
             for option_config in profile.get('profile_options', {}).values():
                 if option_config.get('choices'):
                     # Don't do anything if choices are not present, and only unlisted_choice

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3130,14 +3130,12 @@ class KubeSpawner(Spawner):
             for option_name, option in profile.get('profile_options').items():
                 unlisted_choice_form_key = f'{option_name}--unlisted-choice'
                 chosen_option = selected_profile_user_options.get(option_name, None)
-                # If none was selected get the default
+                # If none was selected get the default. At least one choice is
+                # guaranteed to have the default set
                 if not chosen_option:
-                    default_option = list(option['choices'].keys())[0]
                     for choice_name, choice in option['choices'].items():
                         if choice.get('default', False):
-                            # explicit default, not the first
-                            default_option = choice_name
-                    chosen_option = default_option
+                            chosen_option = choice_name
 
                 # Handle override for unlisted_choice free text specified by user
                 if (

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -3185,6 +3185,9 @@ class KubeSpawner(Spawner):
           default
 
         The profile_list passed in is mutated and returned.
+
+        This function is *idempotent*, you can pass the same profile_list
+        through it as many times without any problems.
         """
         for profile in profile_list:
             # generate missing slug fields from display_name

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2948,7 +2948,6 @@ class KubeSpawner(Spawner):
 
     async def _render_options_form_dynamically(self, current_spawner):
         profile_list = await maybe_future(self.profile_list(current_spawner))
-        profile_list = self._populate_profile_list_defaults(profile_list)
         return self._render_options_form(profile_list)
 
     @default('options_form')

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -21,6 +21,7 @@ import pytest
                 {
                     'display_name': 'Something without a slug',
                     'slug': 'something-without-a-slug',
+                    'default': True,
                     'kubespawner_override': {},
                 },
                 {
@@ -39,41 +40,40 @@ import pytest
                 {
                     'display_name': 'Something with choices',
                     'kubespawner_override': {},
+                    'default': True,
                     'profile_options': {
                         'no-defaults': {
                             'display_name': 'Some choice without a default set',
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
-                                    'kubespawner_override': {}
-                                }
-                            }
+                                    'kubespawner_override': {},
+                                },
+                            },
                         },
                         'only-unlisted': {
                             'display_name': 'Some option without any choices set',
-                            'unlisted_choice': {
-                                'enabled': True
-                            }
+                            'unlisted_choice': {'enabled': True},
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
                                     'default': True,
-                                    'kubespawner_override': {}
-                                }
-                            }
-                        }
-                    }
+                                    'kubespawner_override': {},
+                                },
+                            },
+                        },
+                    },
                 },
             ],
             [
@@ -85,6 +85,7 @@ import pytest
                 {
                     'display_name': 'Something with choices',
                     'slug': 'something-with-choices',
+                    'default': True,
                     'kubespawner_override': {},
                     'profile_options': {
                         'no-defaults': {
@@ -93,35 +94,33 @@ import pytest
                                 'option-1': {
                                     'display_name': 'Option 1',
                                     'default': True,
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
-                                    'kubespawner_override': {}
-                                }
-                            }
+                                    'kubespawner_override': {},
+                                },
+                            },
                         },
                         'only-unlisted': {
                             'display_name': 'Some option without any choices set',
-                            'unlisted_choice': {
-                                'enabled': True
-                            }
+                            'unlisted_choice': {'enabled': True},
                         },
                         'explicit-defaults': {
                             'display_name': 'Some choice with a default set',
                             'choices': {
                                 'option-1': {
                                     'display_name': 'Option 1',
-                                    'kubespawner_override': {}
+                                    'kubespawner_override': {},
                                 },
                                 'option-2': {
                                     'display_name': 'Option 2',
                                     'default': True,
-                                    'kubespawner_override': {}
-                                }
-                            }
-                        }
-                    }
+                                    'kubespawner_override': {},
+                                },
+                            },
+                        },
+                    },
                 },
             ],
         ),
@@ -138,3 +137,52 @@ async def test_profile_missing_defaults_populated(
         spawner._populate_profile_list_defaults(unfilled_profile_list)
         == filled_profile_list
     )
+
+
+@pytest.mark.parametrize(
+    "profile_list,slug,selected_profile,exception",
+    [
+        (
+            [
+                {
+                    'display_name': 'profile 1',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'profile 2',
+                    'kubespawner_override': {},
+                },
+            ],
+            'profile-2',
+            {
+                'display_name': 'profile 2',
+                'slug': 'profile-2',
+                'kubespawner_override': {},
+            },
+        ),
+        (
+            [
+                {
+                    'display_name': 'profile 1',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'profile 2',
+                    'default': True,
+                    'kubespawner_override': {},
+                },
+            ],
+            '',
+            {
+                'display_name': 'profile 2',
+                'slug': 'profile-2',
+                'default': True,
+                'kubespawner_override': {},
+            },
+        ),
+    ],
+)
+async def test_find_slug(profile_list, slug, selected_profile):
+    spawner = KubeSpawner(_mock=True)
+    spawner.profile_list = profile_list
+    assert spawner._get_profile(slug) == selected_profile

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,140 @@
+from kubespawner import KubeSpawner
+import pytest
+
+
+@pytest.mark.parametrize(
+    "unfilled_profile_list,filled_profile_list",
+    [
+        (
+            [
+                {
+                    'display_name': 'Something without a slug',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with a slug',
+                    'slug': 'sluggity-slug',
+                    'kubespawner_override': {},
+                },
+            ],
+            [
+                {
+                    'display_name': 'Something without a slug',
+                    'slug': 'something-without-a-slug',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with a slug',
+                    'slug': 'sluggity-slug',
+                    'kubespawner_override': {},
+                },
+            ],
+        ),
+        (
+            [
+                {
+                    'display_name': 'Something without choices',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with choices',
+                    'kubespawner_override': {},
+                    'profile_options': {
+                        'no-defaults': {
+                            'display_name': 'Some choice without a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        },
+                        'only-unlisted': {
+                            'display_name': 'Some option without any choices set',
+                            'unlisted_choice': {
+                                'enabled': True
+                            }
+                        },
+                        'explicit-defaults': {
+                            'display_name': 'Some choice with a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'default': True,
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        }
+                    }
+                },
+            ],
+            [
+                {
+                    'display_name': 'Something without choices',
+                    'slug': 'something-without-choices',
+                    'kubespawner_override': {},
+                },
+                {
+                    'display_name': 'Something with choices',
+                    'slug': 'something-with-choices',
+                    'kubespawner_override': {},
+                    'profile_options': {
+                        'no-defaults': {
+                            'display_name': 'Some choice without a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'default': True,
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        },
+                        'only-unlisted': {
+                            'display_name': 'Some option without any choices set',
+                            'unlisted_choice': {
+                                'enabled': True
+                            }
+                        },
+                        'explicit-defaults': {
+                            'display_name': 'Some choice with a default set',
+                            'choices': {
+                                'option-1': {
+                                    'display_name': 'Option 1',
+                                    'kubespawner_override': {}
+                                },
+                                'option-2': {
+                                    'display_name': 'Option 2',
+                                    'default': True,
+                                    'kubespawner_override': {}
+                                }
+                            }
+                        }
+                    }
+                },
+            ],
+        ),
+    ],
+)
+async def test_profile_missing_defaults_populated(
+    unfilled_profile_list, filled_profile_list
+):
+    """
+    Tests that missing profileList values are populated
+    """
+    spawner = KubeSpawner(_mock=True)
+    assert (
+        spawner._populate_profile_list_defaults(unfilled_profile_list)
+        == filled_profile_list
+    )


### PR DESCRIPTION
Based primarily on https://github.com/batpad/kubespawner/pull/1

- Have a single function that makes sure slugs are set and defaults are set. This
  allows all other code to assume these are always set, simplifying it. Centralizing
  all this autogeneration code in one place (+ adding a test for it) helps. We don't
  need to specialcase any code for defaults in our HTML template anymore
- Remove `self._profile_list` instance variable, so it is easier to reason about
  profile_list. Everyone who wants it gets it from `self.profile_list` and then passes
  through the defaults setting function.
- Split the large `_load_profile` function into smaller pieces so it is easier to reason
  about.